### PR TITLE
fix: add variants to month classname and adjust initial year

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Visit http://localhost:6006/
 
 ```typescript
 
+
 onRangeSelect: (params: RangeParams) => void
 
 type RangeParams = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viniarruda/react-month-range-picker",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "Vinicius Arruda",
   "description": "React Month Range Picker",
   "types": "types/index.d.ts",

--- a/src/MonthRangePicker/MonthRangePicker.stories.tsx
+++ b/src/MonthRangePicker/MonthRangePicker.stories.tsx
@@ -76,8 +76,9 @@ const TemplateTwoColumns: StoryFn<MonthRangePickerProps> = () => {
       <MonthRangePicker
         onRangeSelect={onRangeSelect}
         columns={2}
-        initialYear={2020}
+        initialYear={2023}
         locale="en-US"
+        monthClassName="month"
       />
       <h1>Initial: {initialDate}</h1>
       <h1>Final: {finalDate}</h1>

--- a/src/MonthRangePicker/index.tsx
+++ b/src/MonthRangePicker/index.tsx
@@ -80,7 +80,7 @@ export const MonthRangePicker: React.FC<MonthRangePickerProps> = ({
     return (
       <Month
         key={month}
-        className={monthClassName}
+        className={`${monthClassName}-${getVariants()}`}
         justify="center"
         disabled={isDisabled}
         variant={getVariants()}
@@ -92,7 +92,7 @@ export const MonthRangePicker: React.FC<MonthRangePickerProps> = ({
   }
 
   const renderYear = (year: number) => (
-    <Row wrap="wrap" justify="center" p="4" css={{ gap: '4px 0' }}>
+    <Row wrap="wrap" justify="center" p="4" rowGap="4">
       {monthsNumber.map(month => renderMonth(year, month))}
     </Row>
   )
@@ -165,12 +165,12 @@ export const MonthRangePicker: React.FC<MonthRangePickerProps> = ({
             </Arrow>
             <Flex mx="4">
               <Typography color="secondary" size="14" weight="regular">
-                {today.getFullYear() + yearOffset}
+                {initialYear + yearOffset}
               </Typography>
             </Flex>
             <Flex mx="4">
               <Typography color="secondary" size="14" weight="regular">
-                {today.getFullYear() + yearOffset + 1}
+                {initialYear + yearOffset + 1}
               </Typography>
             </Flex>
             <Arrow onClick={handleNextYear}>
@@ -178,7 +178,7 @@ export const MonthRangePicker: React.FC<MonthRangePickerProps> = ({
             </Arrow>
           </Row>
           <Flex gap="4">
-            {renderYear(today.getFullYear() + yearOffset)}
+            {renderYear(initialYear + yearOffset)}
             {renderYear(today.getFullYear() + yearOffset + 1)}
           </Flex>
         </Calender>

--- a/src/MonthRangePicker/index.tsx
+++ b/src/MonthRangePicker/index.tsx
@@ -80,7 +80,7 @@ export const MonthRangePicker: React.FC<MonthRangePickerProps> = ({
     return (
       <Month
         key={month}
-        className={`${monthClassName}-${getVariants()}`}
+        className={`${monthClassName}_${getVariants()}`}
         justify="center"
         disabled={isDisabled}
         variant={getVariants()}


### PR DESCRIPTION
- increment variant to `monthClassName`
  - `start`
  - `end`
  - `selected`
  
  for example, if you pass `monthClassName="month"`, you can style using `month_start`, `month_end` and `month_selected`
  

- use `initialYear` to control the currentYear showed




<img width="1547" alt="Screenshot 2024-02-09 at 12 52 53" src="https://github.com/viniarruda/react-month-range-picker/assets/19275982/b39ef8f1-bdc0-4004-bf35-a4f50b8ba0b9">

  
  
  
  
  
  
  